### PR TITLE
add vp9 support

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -314,8 +314,8 @@ if build "x264" "5db6aa6"; then
   execute make install-lib-static
 
   build_done "x264" "5db6aa6"
-  CONFIGURE_OPTIONS+=("--enable-libx264")
 fi
+CONFIGURE_OPTIONS+=("--enable-libx264")
 
 ##
 ## FFmpeg

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -317,6 +317,23 @@ if build "x264" "5db6aa6"; then
 fi
 CONFIGURE_OPTIONS+=("--enable-libx264")
 
+if build "libvpx" "1.13.0"; then
+  download "https://github.com/webmproject/libvpx/archive/refs/tags/v1.13.0.tar.gz" "libvpx-1.13.0.tar.gz"
+
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Applying Darwin patch"
+    sed "s/,--version-script//g" build/make/Makefile >build/make/Makefile.patched
+    sed "s/-Wl,--no-undefined -Wl,-soname/-Wl,-undefined,error -Wl,-install_name/g" build/make/Makefile.patched >build/make/Makefile
+  fi
+
+  execute ./configure --prefix="${WORKSPACE}" --disable-unit-tests --disable-shared --disable-examples --as=yasm --enable-vp9-highbitdepth
+  execute make -j $MJOBS
+  execute make install
+
+  build_done "libvpx" "1.13.0"
+fi
+CONFIGURE_OPTIONS+=("--enable-libvpx")
+
 ##
 ## FFmpeg
 ##
@@ -355,7 +372,6 @@ download "${FFMPEG_URL}" "FFmpeg-release-$FFMPEG_VERSION.tar.gz"
 	\
   --enable-nonfree \
   --enable-gpl \
-  --enable-libvpx \
   \
   --disable-xlib \
   --disable-libxcb-shm \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -315,7 +315,6 @@ if build "x264" "5db6aa6"; then
 
   build_done "x264" "5db6aa6"
 fi
-CONFIGURE_OPTIONS+=("--enable-libx264")
 
 ##
 ## FFmpeg
@@ -355,6 +354,8 @@ download "${FFMPEG_URL}" "FFmpeg-release-$FFMPEG_VERSION.tar.gz"
 	\
   --enable-nonfree \
   --enable-gpl \
+  --enable-libx264 \
+  --enable-libvpx \
   \
   --disable-xlib \
   --disable-libxcb-shm \

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -314,6 +314,7 @@ if build "x264" "5db6aa6"; then
   execute make install-lib-static
 
   build_done "x264" "5db6aa6"
+  CONFIGURE_OPTIONS+=("--enable-libx264")
 fi
 
 ##
@@ -354,7 +355,6 @@ download "${FFMPEG_URL}" "FFmpeg-release-$FFMPEG_VERSION.tar.gz"
 	\
   --enable-nonfree \
   --enable-gpl \
-  --enable-libx264 \
   --enable-libvpx \
   \
   --disable-xlib \


### PR DESCRIPTION
Add `vp9` encoder using `--enable-libvpx` as per https://trac.ffmpeg.org/wiki/CompilationGuide/macOS#Additionallibraries

~Minor (I can back this out), I moved `--enable-libx264` below `--enable-gpl` as that seemed more idiomatic.~ [edit: never mind, looked upstream, putting it back to support easier comparison to upstream]

Tested locally. I didn't include artifacts as I don't have `cargo` installed, saw `rav1e encoder will not be available` warning, not sure which version of `rust` is needed. [edit: looked upstream, looks like this warning is not meaningful w/o `--enable-librav1e`]

I can add artifacts if you'd prefer.

Using this build, I was able to use "smart cut" with a `vp9` + `aac` `.mkv` file, which prior had not been possible, for obvious reasons.

Edit: According to the sources below, `libvpx` is already available in all the other static binaries supplied by https://github.com/mifi/ffmpeg-builds:
`darwin-x64`: https://evermeet.cx/ffmpeg/
`linux-x64`: https://johnvansickle.com/ffmpeg/release-readme.txt
`win32-x64`: https://www.gyan.dev/ffmpeg/builds/#libraries

Edit: Comparison of the various builds: https://gist.github.com/mrienstra/f6cf49b530f14a072cd6d56354fcba04 -- thinking it might be wise to bring the `darwin-arm64` build a little closer to the other 3, to reduce the likelihood of issues like the one this PR is addressing -- something that is broken when using `darwin-arm64`, but works everywhere else.